### PR TITLE
Revert "Support for local LLM using ollama on macOS15 (ollama branch)"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
   name: "scg",
   platforms: [
-    .macOS(.v15)
+    .macOS(.v26)
   ],
   products: [
     .executable(name: "scg", targets: ["SwiftCommitGen"])
@@ -20,11 +20,8 @@ let package = Package(
       dependencies: [
         .product(name: "ArgumentParser", package: "swift-argument-parser")
       ],
-      swiftSettings: [
-        .unsafeFlags(
-          ["-Xfrontend", "-warn-long-function-bodies=500"],
-          .when(configuration: .debug)
-        )
+      linkerSettings: [
+        .linkedFramework("FoundationModels")
       ]
     ),
     .testTarget(

--- a/README.md
+++ b/README.md
@@ -1,23 +1,17 @@
 scg
 ===
 
-scg is a Swift-based command line tool that inspects your current Git repository, summarizes the staged and unstaged changes, and generates a commit message proposal using AI. The tool supports two backends:
-
-- **FoundationModels** (macOS 26+): Uses Apple's on-device generative model for privacy-preserving, local-only generation
-- **Ollama** (macOS 15+): Uses locally-hosted Ollama models for flexible, self-hosted AI generation
-
-The goal is to keep human-in-the-loop Git commits fast, consistent, and privacy-preserving by relying on local AI capabilities instead of cloud services.
+scg is a Swift-based command line tool that inspects your current Git repository, summarizes the staged and unstaged changes, and generates a commit message proposal with Apple's on-device generative model. The goal is to keep human-in-the-loop Git commits fast, consistent, and privacy-preserving by relying on system-provided AI capabilities instead of cloud services.
 
 https://github.com/user-attachments/assets/499e7b11-86af-490f-bb4e-c49c65c58ecf
 
 Features
 --------
 - Detects dirty Git worktrees and extracts concise change context
-- Crafts commit message drafts with local AI models (FoundationModels or Ollama)
+- Crafts commit message drafts with Apple's onboard generative APIs
 - Provides an interactive acceptance/edit flow before writing the commit
 - Persists CLI defaults with an interactive `config` command
-- Respects local-only privacy requirements (no network calls to cloud services)
-- Flexible LLM backend support: choose between Apple Intelligence or Ollama
+- Respects local-only privacy requirements (no network calls)
 
 Project Status
 --------------
@@ -25,21 +19,11 @@ The CLI currently supports end-to-end commit generation, including Git inspectio
 
 Prerequisites
 -------------
-
-### For FoundationModels (macOS 26+)
 - macOS Tahoe (26) or later with the Apple Intelligence feature set enabled
 - Xcode 26 (or newer) with the command line tools installed (`xcode-select --install`)
 - Swift 6 toolchain (ships with Xcode 26)
-- Full Disk Access enabled for the Terminal (or your preferred shell) so the FoundationModels framework can initialize properly
-
-### For Ollama (macOS 15+)
-- macOS Sequoia (15) or later
-- Xcode 16.1+ with Swift 6.1 toolchain
-- [Ollama](https://ollama.ai) installed and running (`brew install ollama`)
-- An Ollama model pulled (e.g., `ollama pull llama3.2`)
-
-### Common Requirements
 - Git 2.40+ available on `PATH`
+- Full Disk Access enabled for the Terminal (or your preferred shell) so the FoundationModels framework can initialize properly
 
 Installation
 ------------
@@ -139,9 +123,6 @@ scg generate [OPTIONS]
 | `--quiet` | `-q` | Suppress routine info lines | Off | Hides `[INFO]` but keeps `[NOTICE]`, warnings, errors. Ignored if `--verbose` is present. |
 | `--no-quiet` |  | Ensure quiet mode is disabled, even if configured | - | Helpful when scripts need full output. |
 | `--single-file` |  | Analyze each file independently and then combine per-file drafts | Off | Sends a larger diff slice per file, useful when you need high-fidelity summaries. |
-| `--llm-provider <foundationModels\|ollama>` |  | Choose the LLM provider | `foundationModels` on macOS 26+, `ollama` on macOS 15 | Select which AI backend to use. |
-| `--ollama-model <name>` |  | Ollama model to use | `llama3.2` | Only applicable when using Ollama provider. |
-| `--ollama-base-url <url>` |  | Ollama API base URL | `http://localhost:11434` | Only applicable when using Ollama provider. |
 
 ### Verbosity Levels
 
@@ -193,30 +174,6 @@ Request high-fidelity per-file drafts before they are combined:
 scg --single-file
 ```
 
-Use Ollama instead of FoundationModels:
-
-```sh
-scg --llm-provider ollama
-```
-
-Use a specific Ollama model:
-
-```sh
-scg --llm-provider ollama --ollama-model codellama:13b
-```
-
-List available Ollama models:
-
-```sh
-scg config --list-ollama-models
-```
-
-Interactively configure your preferences (including Ollama model selection):
-
-```sh
-scg config
-```
-
 Configuration Defaults
 ----------------------
 Use the `config` subcommand to inspect or update stored defaults. Running it with no flags opens an interactive, colorized editor that walks through each preference:
@@ -225,35 +182,19 @@ Use the `config` subcommand to inspect or update stored defaults. Running it wit
 scg config
 ```
 
-The interactive editor will guide you through:
-1. **Auto-stage preference**: Whether to automatically stage files when nothing is staged
-2. **Default verbosity**: Choose between standard, verbose, or quiet output
-3. **Generation mode**: Select automatic or per-file analysis
-4. **LLM Provider**: Choose between FoundationModels (macOS 26+) or Ollama (macOS 15+)
-5. **Ollama Model** (if Ollama selected): Interactive selection from your installed Ollama models
-
-Available command-line options:
+Available options:
 
 | Flag | Description |
 |------|-------------|
 | `--show` | Print the current configuration without making changes. |
-| `--list-ollama-models` | List all Ollama models installed on your system. |
 | `--auto-stage-if-clean <true\|false>` | Persist whether `generate` should stage all files when nothing is staged. |
 | `--clear-auto-stage` | Remove the stored auto-stage preference. |
 | `--verbose <true\|false>` | Set the default verbose logging preference. |
 | `--clear-verbose` | Remove the stored verbose preference. |
 | `--quiet <true\|false>` | Set the default quiet logging preference. |
 | `--clear-quiet` | Remove the stored quiet preference. |
-| `--generation-mode <automatic\|perFile>` | Set the default generation mode. |
-| `--clear-generation-mode` | Remove the stored generation mode preference. |
-| `--llm-provider <foundationModels\|ollama>` | Set the default LLM provider. |
-| `--clear-llm-provider` | Remove the stored LLM provider preference. |
-| `--ollama-model <name>` | Set the default Ollama model name. |
-| `--ollama-base-url <url>` | Set the default Ollama base URL. |
 
-When no options are provided, the command detects whether the terminal is interactive and presents guided prompts with recommended defaults highlighted. For Ollama users, the interactive mode automatically fetches your installed models from `ollama list` and presents them as numbered choices.
-
-Stored settings live in `~/Library/Application Support/scg/config.json`.
+When no options are provided, the command detects whether the terminal is interactive and presents guided prompts with recommended defaults highlighted. Stored settings live in `~/Library/Application Support/scg/config.json`.
 
 ### Help
 

--- a/Sources/SwiftCommitGen/CommitGenOptions.swift
+++ b/Sources/SwiftCommitGen/CommitGenOptions.swift
@@ -1,15 +1,7 @@
-#if canImport(FoundationModels)
-  @_weakLinked import FoundationModels
-#endif
+import FoundationModels
 
 /// Container for the resolved configuration driving a commit generation run.
 struct CommitGenOptions {
-  /// Supported LLM providers for commit generation.
-  enum LLMProvider: Codable, Equatable {
-    case foundationModels
-    case ollama(model: String, baseURL: String)
-  }
-
   /// Supported output formats for the rendered draft.
   enum OutputFormat: String, Codable {
     case text
@@ -17,14 +9,12 @@ struct CommitGenOptions {
   }
 
   /// Available prompt styles that influence how instructions are sent to the model.
-  enum PromptStyle: String, Codable {
+  enum PromptStyle: String, PromptRepresentable, Codable {
     case detailed
 
-    #if canImport(FoundationModels)
-      var promptRepresentation: Prompt {
-        Prompt { styleGuidance }
-      }
-    #endif
+    var promptRepresentation: Prompt {
+      Prompt { styleGuidance }
+    }
 
     var styleGuidance: String {
       "Style: use the body for a few short sentences covering rationale and impact; separate points with sentences rather than markdown bullets."
@@ -37,8 +27,6 @@ struct CommitGenOptions {
     case perFile
   }
 
-  /// LLM provider to use for commit generation.
-  var llmProvider: LLMProvider
   /// Desired format for logging or piping the generated draft.
   var outputFormat: OutputFormat
   /// Prompt template variant to use when communicating with the model.

--- a/Sources/SwiftCommitGen/CommitGenTool.swift
+++ b/Sources/SwiftCommitGen/CommitGenTool.swift
@@ -18,7 +18,7 @@ struct CommitGenTool {
     gitClient: GitClient = SystemGitClient(),
     summarizer: DiffSummarizer? = nil,
     promptBuilder: PromptBuilder? = nil,
-    llmClient: LLMClient? = nil,
+    llmClient: LLMClient = FoundationModelsClient(),
     renderer: Renderer = ConsoleRenderer(),
     logger: CommitGenLogger? = nil
   ) {
@@ -29,8 +29,8 @@ struct CommitGenTool {
       self.summarizer = summarizer
     } else {
       let perFileMode = options.generationMode == .perFile
-      let maxLines = perFileMode ? 500 : 300
-      let maxFullLines = perFileMode ? 1000 : 500
+      let maxLines = perFileMode ? 200 : 80
+      let maxFullLines = perFileMode ? 400 : 200
       self.summarizer = DefaultDiffSummarizer(
         gitClient: gitClient,
         maxLinesPerFile: maxLines,
@@ -57,29 +57,7 @@ struct CommitGenTool {
     } else {
       self.promptBuilder = DefaultPromptBuilder()
     }
-
-    if let llmClient {
-      self.llmClient = llmClient
-    } else {
-      switch options.llmProvider {
-      case .ollama(let model, let baseURL):
-        let config = OllamaClient.Configuration(
-          model: model,
-          baseURL: baseURL,
-          logger: logger ?? CommitGenLogger(isVerbose: options.isVerbose, isQuiet: options.isQuiet)
-
-        )
-        self.llmClient = OllamaClient(configuration: config)
-      #if canImport(FoundationModels)
-        case .foundationModels:
-          self.llmClient = FoundationModelsClient()
-      #else
-        case .foundationModels:
-          fatalError("FoundationModels is not available on this platform")
-      #endif
-      }
-    }
-
+    self.llmClient = llmClient
     self.renderer = renderer
     self.logger = logger ?? CommitGenLogger(isVerbose: options.isVerbose, isQuiet: options.isQuiet)
     self.consoleTheme = self.logger.consoleTheme
@@ -347,28 +325,12 @@ struct CommitGenTool {
 
     do {
       try process.run()
-
-      // Give TTY control to the child process only if we are in a TTY
-      if isatty(STDIN_FILENO) != 0 {
-        let childPgid = process.processIdentifier
-        // Set the child's process group
-        setpgid(childPgid, childPgid)
-        // Give TTY control to the child
-        tcsetpgrp(STDIN_FILENO, childPgid)
-      }
     } catch {
       logger.warning("Failed to launch $EDITOR (\(editor)): \(error.localizedDescription)")
       return nil
     }
 
     process.waitUntilExit()
-
-    // IMPORTANT: Return control of the TTY to the parent process
-    if isatty(STDIN_FILENO) != 0 {
-      let parentPgid = getpgrp()
-      tcsetpgrp(STDIN_FILENO, parentPgid)
-    }
-
     guard process.terminationStatus == 0 else {
       logger.warning(
         "Editor exited with status \(process.terminationStatus); keeping previous draft."

--- a/Sources/SwiftCommitGen/ConfigCommand.swift
+++ b/Sources/SwiftCommitGen/ConfigCommand.swift
@@ -71,38 +71,8 @@ struct ConfigCommand: ParsableCommand {
   @Flag(name: .customLong("clear-mode"), help: "Remove the stored generation mode preference.")
   var clearMode: Bool = false
 
-  @Option(name: .long, help: "Set the default LLM provider (foundationModels|ollama).")
-  var llmProvider: String?
-
-  @Flag(name: .customLong("clear-llm-provider"), help: "Remove the stored LLM provider preference.")
-  var clearLLMProvider: Bool = false
-
-  @Option(name: .long, help: "Set the default Ollama model name.")
-  var ollamaModel: String?
-
-  @Flag(name: .customLong("list-ollama-models"), help: "List available Ollama models.")
-  var listOllamaModels: Bool = false
-
-  @Flag(name: .customLong("clear-ollama-model"), help: "Remove the stored Ollama model preference.")
-  var clearOllamaModel: Bool = false
-
-  @Option(name: .long, help: "Set the default Ollama base URL.")
-  var ollamaBaseURL: String?
-
-  @Flag(
-    name: .customLong("clear-ollama-base-url"),
-    help: "Remove the stored Ollama base URL preference."
-  )
-  var clearOllamaBaseURL: Bool = false
-
   /// Runs the `scg config` subcommand either interactively or via direct flag updates.
   func run() throws {
-    // Handle list-ollama-models flag first
-    if listOllamaModels {
-      listAvailableOllamaModels()
-      return
-    }
-
     try validateOptions()
     let dependencies = ConfigCommand.resolveDependencies()
     let store = dependencies.makeStore()
@@ -154,15 +124,6 @@ struct ConfigCommand: ParsableCommand {
     if mode != nil && clearMode {
       throw ValidationError("Cannot use --mode together with --clear-mode.")
     }
-    if llmProvider != nil && clearLLMProvider {
-      throw ValidationError("Cannot use --llm-provider together with --clear-llm-provider.")
-    }
-    if ollamaModel != nil && clearOllamaModel {
-      throw ValidationError("Cannot use --ollama-model together with --clear-ollama-model.")
-    }
-    if ollamaBaseURL != nil && clearOllamaBaseURL {
-      throw ValidationError("Cannot use --ollama-base-url together with --clear-ollama-base-url.")
-    }
   }
 
   /// Returns true when the command should launch the interactive editor.
@@ -176,13 +137,6 @@ struct ConfigCommand: ParsableCommand {
       && !clearQuiet
       && mode == nil
       && !clearMode
-      && llmProvider == nil
-      && !clearLLMProvider
-      && ollamaModel == nil
-      && !clearOllamaModel
-      && !listOllamaModels
-      && ollamaBaseURL == nil
-      && !clearOllamaBaseURL
   }
 
   /// Applies configuration updates coming from explicit CLI flags.
@@ -257,63 +211,6 @@ struct ConfigCommand: ParsableCommand {
       }
     }
 
-    if clearLLMProvider {
-      if configuration.llmProvider != nil {
-        configuration.llmProvider = nil
-        changed = true
-      }
-    }
-    if let providerString = llmProvider {
-      let newProvider: CommitGenOptions.LLMProvider?
-      switch providerString.lowercased() {
-      case "foundationmodels":
-        newProvider = .foundationModels
-      case "ollama":
-        // Get current ollama settings or use defaults
-        let currentModel: String
-        let currentBaseURL: String
-        if case .ollama(let model, let baseURL) = configuration.llmProvider {
-          currentModel = model
-          currentBaseURL = baseURL
-        } else {
-          currentModel = "llama3.2"
-          currentBaseURL = "http://localhost:11434"
-        }
-        // Override with CLI args if provided
-        let finalModel = ollamaModel ?? currentModel
-        let finalBaseURL = ollamaBaseURL ?? currentBaseURL
-        newProvider = .ollama(model: finalModel, baseURL: finalBaseURL)
-      default:
-        print(
-          "Warning: Invalid LLM provider '\(providerString)'. Use 'foundationModels' or 'ollama'."
-        )
-        newProvider = nil
-      }
-
-      if let newProvider, configuration.llmProvider != newProvider {
-        configuration.llmProvider = newProvider
-        changed = true
-      }
-    } else if ollamaModel != nil || ollamaBaseURL != nil {
-      // Update Ollama settings only if already using Ollama
-      if case .ollama(let currentModel, let currentBaseURL) = configuration.llmProvider {
-        let finalModel = ollamaModel ?? currentModel
-        let finalBaseURL = ollamaBaseURL ?? currentBaseURL
-        let newProvider = CommitGenOptions.LLMProvider.ollama(
-          model: finalModel,
-          baseURL: finalBaseURL
-        )
-        if configuration.llmProvider != newProvider {
-          configuration.llmProvider = newProvider
-          changed = true
-        }
-      } else {
-        print(
-          "Warning: --ollama-model and --ollama-base-url only apply when using Ollama provider."
-        )
-      }
-    }
-
     return changed
   }
 
@@ -381,193 +278,6 @@ struct ConfigCommand: ParsableCommand {
       ],
       theme: theme
     )
-
-    // LLM Provider
-    #if canImport(FoundationModels)
-      let defaultLLMProvider: CommitGenOptions.LLMProvider = .foundationModels
-      let foundationModelsRecommended = true
-      let ollamaRecommended = false
-    #else
-      let defaultLLMProvider: CommitGenOptions.LLMProvider = .ollama(
-        model: "llama3.2",
-        baseURL: "http://localhost:11434"
-      )
-      let foundationModelsRecommended = false
-      let ollamaRecommended = true
-    #endif
-
-    let currentLLMProvider = configuration.llmProvider ?? defaultLLMProvider
-    let isUsingFoundationModels: Bool
-    let isUsingOllama: Bool
-    switch currentLLMProvider {
-    case .foundationModels:
-      isUsingFoundationModels = true
-      isUsingOllama = false
-    case .ollama:
-      isUsingFoundationModels = false
-      isUsingOllama = true
-    }
-
-    let llmProviderNote = configuration.llmProvider == nil ? "(default)" : nil
-
-    printPreference(
-      title: "LLM Provider",
-      choices: [
-        DisplayChoice(
-          name: "foundationModels",
-          isCurrent: isUsingFoundationModels,
-          isRecommended: foundationModelsRecommended,
-          note: isUsingFoundationModels ? llmProviderNote : nil
-        ),
-        DisplayChoice(
-          name: "ollama",
-          isCurrent: isUsingOllama,
-          isRecommended: ollamaRecommended,
-          note: isUsingOllama ? llmProviderNote : nil
-        ),
-      ],
-      theme: theme
-    )
-
-    // Show Ollama model as a separate preference if Ollama is the provider
-    if case .ollama(let model, let baseURL) = currentLLMProvider {
-      // Get available models to show them as options
-      let availableModels = fetchOllamaModels(baseURL: baseURL)
-
-      if !availableModels.isEmpty {
-        var modelChoices: [DisplayChoice] = []
-        for availableModel in availableModels {
-          // Normalize model names for comparison (handle :latest suffix)
-          let normalizedAvailable =
-            availableModel.hasSuffix(":latest")
-            ? String(availableModel.dropLast(7))
-            : availableModel
-          let normalizedCurrent =
-            model.hasSuffix(":latest")
-            ? String(model.dropLast(7))
-            : model
-
-          let isCurrentModel = normalizedAvailable == normalizedCurrent || availableModel == model
-
-          modelChoices.append(
-            DisplayChoice(
-              name: availableModel,
-              isCurrent: isCurrentModel,
-              isRecommended: false
-            )
-          )
-        }
-
-        printPreference(
-          title: "Ollama Model",
-          choices: modelChoices,
-          theme: theme
-        )
-      } else {
-        // If can't fetch models, just show the current one
-        print(theme.applying(theme.emphasis, to: "Ollama Model:"))
-        print("  > \(model) " + theme.applying(theme.infoLabel, to: "[current]"))
-        print("")
-      }
-
-      print(theme.applying(theme.emphasis, to: "Ollama Base URL:"))
-      print("  \(baseURL)")
-      print("")
-    }
-  }
-
-  /// Fetches available models from Ollama API.
-  private func fetchOllamaModels(baseURL: String) -> [String] {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["ollama", "list"]
-
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = Pipe()
-
-    do {
-      try process.run()
-      process.waitUntilExit()
-
-      guard process.terminationStatus == 0 else {
-        return []
-      }
-
-      let data = pipe.fileHandleForReading.readDataToEndOfFile()
-      guard let output = String(data: data, encoding: .utf8) else {
-        return []
-      }
-
-      // Parse ollama list output
-      // Format: NAME                    ID              SIZE      MODIFIED
-      var models: [String] = []
-      let lines = output.split(separator: "\n")
-      for (index, line) in lines.enumerated() {
-        // Skip header line
-        if index == 0 { continue }
-
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty { continue }
-
-        // Get the first column (model name)
-        let columns = trimmed.split(separator: " ", omittingEmptySubsequences: true)
-        if let modelName = columns.first {
-          models.append(String(modelName))
-        }
-      }
-
-      return models
-    } catch {
-      return []
-    }
-  }
-
-  /// Lists available Ollama models by executing `ollama list`.
-  private func listAvailableOllamaModels() {
-    let theme = ConsoleTheme.resolve(stream: .stdout)
-
-    print(theme.applying(theme.emphasis, to: "Available Ollama models:"))
-    print("")
-
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["ollama", "list"]
-
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    let errorPipe = Pipe()
-    process.standardError = errorPipe
-
-    do {
-      try process.run()
-      process.waitUntilExit()
-
-      if process.terminationStatus != 0 {
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        if let errorMessage = String(data: errorData, encoding: .utf8), !errorMessage.isEmpty {
-          print(theme.applying(theme.muted, to: "Error: \(errorMessage)"))
-        } else {
-          print(
-            theme.applying(
-              theme.muted,
-              to: "Error: Could not fetch Ollama models. Make sure Ollama is installed and running."
-            )
-          )
-        }
-        return
-      }
-
-      let data = pipe.fileHandleForReading.readDataToEndOfFile()
-      if let output = String(data: data, encoding: .utf8) {
-        print(output)
-        print("")
-        print(theme.applying(theme.muted, to: "To set a default model, use:"))
-        print(theme.applying(theme.path, to: "  scg config --ollama-model <model-name>"))
-      }
-    } catch {
-      print(theme.applying(theme.muted, to: "Error: \(error.localizedDescription)"))
-    }
   }
 }
 
@@ -745,30 +455,11 @@ struct ConfigInteractiveEditor {
       }
     }
 
-    if let llmChoice = promptForLLMProvider(current: configuration.llmProvider) {
-      switch llmChoice {
-      case .foundationModels:
-        updated.llmProvider = .foundationModels
-      case .ollama(let model, let baseURL):
-        updated.llmProvider = .ollama(model: model, baseURL: baseURL)
-      case .clear:
-        updated.llmProvider = nil
-      }
-    }
-
-    // If Ollama is selected, prompt for model selection
-    if case .ollama(let currentModel, let currentBaseURL) = updated.llmProvider {
-      if let selectedModel = promptForOllamaModel(current: currentModel, baseURL: currentBaseURL) {
-        updated.llmProvider = .ollama(model: selectedModel, baseURL: currentBaseURL)
-      }
-    }
-
     let changed =
       updated.autoStageIfNoStaged != original.autoStageIfNoStaged
       || updated.defaultVerbose != original.defaultVerbose
       || updated.defaultQuiet != original.defaultQuiet
       || updated.defaultGenerationMode != original.defaultGenerationMode
-      || updated.llmProvider != original.llmProvider
 
     return (updated, changed)
   }
@@ -874,233 +565,6 @@ struct ConfigInteractiveEditor {
         }
       }
     )
-  }
-
-  /// Presents a numbered menu for choosing the LLM provider.
-  private func promptForLLMProvider(
-    current: CommitGenOptions.LLMProvider?
-  ) -> LLMProviderChoice? {
-    let currentProvider =
-      current
-      ?? {
-        #if canImport(FoundationModels)
-          return CommitGenOptions.LLMProvider.foundationModels
-        #else
-          return CommitGenOptions.LLMProvider.ollama(
-            model: "llama3.2",
-            baseURL: "http://localhost:11434"
-          )
-        #endif
-      }()
-
-    let currentDescription: String
-    switch currentProvider {
-    case .foundationModels:
-      currentDescription = "foundationModels"
-    case .ollama:
-      currentDescription = "ollama"
-    }
-
-    let choices: [Choice<LLMProviderChoice>] = [
-      Choice(
-        label: "1",
-        tokens: ["1", "foundationmodels", "fm", "foundation"],
-        description: "foundationModels (macOS 26+)",
-        value: .foundationModels,
-        isRecommended: {
-          #if canImport(FoundationModels)
-            return true
-          #else
-            return false
-          #endif
-        }()
-      ),
-      Choice(
-        label: "2",
-        tokens: ["2", "ollama", "o"],
-        description: "ollama (local models)",
-        value: .ollama(model: "", baseURL: ""),
-        isRecommended: {
-          #if canImport(FoundationModels)
-            return false
-          #else
-            return true
-          #endif
-        }()
-      ),
-      Choice(
-        label: "",
-        tokens: ["clear", "reset"],
-        description: "",
-        value: .clear,
-        isVisible: false
-      ),
-    ]
-
-    let choice = promptChoice(
-      title: "LLM Provider",
-      currentDescription: currentDescription,
-      choices: choices,
-      keepMessage: "Press Enter to keep current provider",
-      isCurrent: { choiceValue in
-        switch (choiceValue, currentProvider) {
-        case (.foundationModels, .foundationModels):
-          return true
-        case (.ollama, .ollama):
-          return true
-        default:
-          return false
-        }
-      },
-      additionalInstructions: ["Type 'clear' to remove the stored preference."]
-    )
-
-    // If user selected Ollama, keep current settings or use defaults
-    guard case .ollama = choice else {
-      return choice
-    }
-
-    // Get current model and baseURL
-    let currentModel: String
-    let currentBaseURL: String
-    if case .ollama(let model, let baseURL) = currentProvider {
-      currentModel = model
-      currentBaseURL = baseURL
-    } else {
-      currentModel = "llama3.2"
-      currentBaseURL = "http://localhost:11434"
-    }
-
-    return .ollama(model: currentModel, baseURL: currentBaseURL)
-  }
-
-  /// Presents a numbered menu for choosing an Ollama model.
-  private func promptForOllamaModel(current: String, baseURL: String) -> String? {
-    // Try to fetch available models from Ollama
-    let availableModels = fetchOllamaModels(baseURL: baseURL)
-
-    if availableModels.isEmpty {
-      // Fallback to manual input if can't fetch models
-      io.printLine("")
-      io.printLine(
-        theme.applying(
-          theme.muted,
-          to: "⚠ Could not fetch models from Ollama. Make sure Ollama is running."
-        )
-      )
-      io.printLine(theme.applying(theme.emphasis, to: "Ollama Model"))
-      io.printLine(theme.applying(theme.muted, to: "  Current: \(current)"))
-      io.printLine(theme.applying(theme.muted, to: "  Press Enter to keep, or type model name:"))
-      let modelResponse = io.prompt("  > ")
-      if let response = modelResponse?.trimmingCharacters(in: .whitespacesAndNewlines),
-        !response.isEmpty
-      {
-        return response
-      }
-      return nil
-    }
-
-    // Show available models
-    io.printLine("")
-
-    // Normalize current model name for comparison (handle :latest suffix)
-    let normalizedCurrent =
-      current.hasSuffix(":latest")
-      ? String(current.dropLast(7))
-      : current
-
-    var modelChoices: [Choice<String>] = []
-    for (index, model) in availableModels.enumerated() {
-      let label = "\(index + 1)"
-
-      // Normalize model name for comparison
-      let normalizedModel =
-        model.hasSuffix(":latest")
-        ? String(model.dropLast(7))
-        : model
-
-      let isCurrentModel = normalizedModel == normalizedCurrent || model == current
-
-      // Build comprehensive token list for matching user input
-      var tokens = [label, model, model.lowercased()]
-      // Add normalized version without :latest
-      if model != normalizedModel {
-        tokens.append(normalizedModel)
-        tokens.append(normalizedModel.lowercased())
-      }
-
-      modelChoices.append(
-        Choice(
-          label: label,
-          tokens: tokens,
-          description: model,
-          value: model,
-          isRecommended: isCurrentModel
-        )
-      )
-    }
-
-    return promptChoice(
-      title: "Ollama Model",
-      currentDescription: current,
-      choices: modelChoices,
-      keepMessage: "Press Enter to keep current model",
-      isCurrent: { selectedModel in
-        let normalizedSelected =
-          selectedModel.hasSuffix(":latest")
-          ? String(selectedModel.dropLast(7))
-          : selectedModel
-        return normalizedSelected == normalizedCurrent || selectedModel == current
-      },
-      additionalInstructions: ["Type model name directly or select by number."]
-    )
-  }
-
-  /// Fetches available models from Ollama API.
-  private func fetchOllamaModels(baseURL: String) -> [String] {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["ollama", "list"]
-
-    let pipe = Pipe()
-    process.standardOutput = pipe
-    process.standardError = Pipe()
-
-    do {
-      try process.run()
-      process.waitUntilExit()
-
-      guard process.terminationStatus == 0 else {
-        return []
-      }
-
-      let data = pipe.fileHandleForReading.readDataToEndOfFile()
-      guard let output = String(data: data, encoding: .utf8) else {
-        return []
-      }
-
-      // Parse ollama list output
-      // Format: NAME                    ID              SIZE      MODIFIED
-      var models: [String] = []
-      let lines = output.split(separator: "\n")
-      for (index, line) in lines.enumerated() {
-        // Skip header line
-        if index == 0 { continue }
-
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty { continue }
-
-        // Get the first column (model name)
-        let columns = trimmed.split(separator: " ", omittingEmptySubsequences: true)
-        if let modelName = columns.first {
-          models.append(String(modelName))
-        }
-      }
-
-      return models
-    } catch {
-      return []
-    }
   }
 
   /// Presents a numbered menu for choosing the default generation mode.
@@ -1235,12 +699,6 @@ struct ConfigInteractiveEditor {
   private enum GenerationModeChoice {
     case automatic
     case perFile
-    case clear
-  }
-
-  private enum LLMProviderChoice {
-    case foundationModels
-    case ollama(model: String, baseURL: String)
     case clear
   }
 }

--- a/Sources/SwiftCommitGen/Core/BatchCombinationPromptBuilder.swift
+++ b/Sources/SwiftCommitGen/Core/BatchCombinationPromptBuilder.swift
@@ -1,8 +1,5 @@
 import Foundation
-
-#if canImport(FoundationModels)
-  @_weakLinked import FoundationModels
-#endif
+import FoundationModels
 
 /// Builds the prompt used to merge per-batch drafts into a single commit message.
 struct BatchCombinationPromptBuilder {
@@ -16,7 +13,7 @@ struct BatchCombinationPromptBuilder {
     userLines.append("Repository: \(metadata.repositoryName)")
     userLines.append("Branch: \(metadata.branchName)")
     userLines.append("Scope: \(metadata.scopeDescription)")
-    userLines.append("Style: \(metadata.style.styleGuidance)")
+    userLines.append("Style: \(metadata.style)")
     userLines.append(
       "We split the diff into \(sortedPartials.count) batch(es) to respect the model context window. Combine the partial commit drafts below into a single cohesive commit message that covers every file."
     )
@@ -57,43 +54,25 @@ struct BatchCombinationPromptBuilder {
       "Produce one final commit subject (<= 50 characters) and an optional body that summarizes the full change set. Avoid repeating the batch headings—present the combined commit message only."
     )
 
-    #if canImport(FoundationModels)
-      let userPrompt = Prompt {
-        for line in userLines {
-          line
-        }
+    let userPrompt = Prompt {
+      for line in userLines {
+        line
       }
+    }
 
-      let systemPrompt = Instructions {
-        """
-        You are an AI assistant merging multiple partial commit drafts into a single, well-structured commit message. 
-        Preserve all important intent from the inputs, avoid redundancy, and keep the final subject concise (<= 50 characters). 
-        The title should succinctly describe the change in a specific and informative manner.
-        Provide an optional body only when useful for additional context. 
-        If a body is present, it should describe the _purpose_ of the change, not just _what_ was changed: focus on the reasoning behind the changes rather than a file-by-file summary.
+    let systemPrompt = Instructions {
+      """
+      You are an AI assistant merging multiple partial commit drafts into a single, well-structured commit message. 
+      Preserve all important intent from the inputs, avoid redundancy, and keep the final subject concise (<= 50 characters). 
+      The title should succinctly describe the change in a specific and informative manner.
+      Provide an optional body only when useful for additional context. 
+      If a body is present, it should describe the _purpose_ of the change, not just _what_ was changed: focus on the reasoning behind the changes rather than a file-by-file summary.
 
-        Be clear and concise, but do not omit critical information.
-        """
-        ""
-        metadata.style.styleGuidance
-      }
-    #else
-      let userPrompt = PromptContent(userLines.joined(separator: "\n"))
-
-      let systemPrompt = PromptContent(
-        """
-        You are an AI assistant merging multiple partial commit drafts into a single, well-structured commit message. 
-        Preserve all important intent from the inputs, avoid redundancy, and keep the final subject concise (<= 50 characters). 
-        The title should succinctly describe the change in a specific and informative manner.
-        Provide an optional body only when useful for additional context. 
-        If a body is present, it should describe the _purpose_ of the change, not just _what_ was changed: focus on the reasoning behind the changes rather than a file-by-file summary.
-
-        Be clear and concise, but do not omit critical information.
-
-        \(metadata.style.styleGuidance)
-        """
-      )
-    #endif
+      Be clear and concise, but do not omit critical information.
+      """
+      ""
+      metadata.style.styleGuidance
+    }
 
     let characterCount = userLines.reduce(0) { $0 + $1.count + 1 }
     let estimatedTokens = PromptDiagnostics.tokenEstimate(forCharacterCount: characterCount)

--- a/Sources/SwiftCommitGen/Core/CommitGenError.swift
+++ b/Sources/SwiftCommitGen/Core/CommitGenError.swift
@@ -8,7 +8,6 @@ enum CommitGenError: Error {
   case modelUnavailable(reason: String)
   case modelTimedOut(timeout: TimeInterval)
   case modelGenerationFailed(message: String)
-  case llmRequestFailed(reason: String)
   case notImplemented
 }
 
@@ -31,8 +30,6 @@ extension CommitGenError: LocalizedError {
       "The on-device language model did not respond within \(formatSeconds(timeout)). Try again shortly or reduce the diff size."
     case .modelGenerationFailed(let message):
       message
-    case .llmRequestFailed(let reason):
-      "LLM request failed: \(reason)"
     case .notImplemented:
       "Commit generation is not implemented yet; future phases will add this capability."
     }

--- a/Sources/SwiftCommitGen/Core/DiffSummarizer.swift
+++ b/Sources/SwiftCommitGen/Core/DiffSummarizer.swift
@@ -1,13 +1,10 @@
 import Foundation
-
-#if canImport(FoundationModels)
-  @_weakLinked import FoundationModels
-#endif
+import FoundationModels
 
 /// Represents the staged changes that will be summarized for prompt construction.
-struct ChangeSummary: Hashable, Codable {
+struct ChangeSummary: Hashable, Codable, PromptRepresentable {
   /// Describes how a single file contributes to the change summary and prompt content.
-  struct FileSummary: Hashable, Codable {
+  struct FileSummary: Hashable, Codable, PromptRepresentable {
     enum SnippetMode: String, Codable {
       case compact
       case full
@@ -52,15 +49,13 @@ struct ChangeSummary: Hashable, Codable {
       }
     }
 
-    #if canImport(FoundationModels)
-      var promptRepresentation: Prompt {
-        Prompt {
-          for line in promptLines() {
-            line
-          }
+    var promptRepresentation: Prompt {
+      Prompt {
+        for line in promptLines() {
+          line
         }
       }
-    #endif
+    }
 
     func estimatedPromptLineCount() -> Int {
       var lines = 1  // header line per file
@@ -197,15 +192,13 @@ struct ChangeSummary: Hashable, Codable {
     files.count
   }
 
-  #if canImport(FoundationModels)
-    var promptRepresentation: Prompt {
-      Prompt {
-        for line in promptLines() {
-          line
-        }
+  var promptRepresentation: Prompt {
+    Prompt {
+      for line in promptLines() {
+        line
       }
     }
-  #endif
+  }
 }
 
 extension ChangeSummary {

--- a/Sources/SwiftCommitGen/Core/LLMClient.swift
+++ b/Sources/SwiftCommitGen/Core/LLMClient.swift
@@ -1,33 +1,21 @@
 import Foundation
-
-#if canImport(FoundationModels)
-  @_weakLinked import FoundationModels
-#endif
+import FoundationModels
 
 /// Abstraction over the on-device language model that generates commit drafts.
 protocol LLMClient {
   func generateCommitDraft(from prompt: PromptPackage) async throws -> LLMGenerationResult
 }
 
-#if canImport(FoundationModels)
-  @Generable(description: "A commit for changes made in a git repository.")
-#endif
+@Generable(description: "A commit for changes made in a git repository.")
 /// Model representation for the subject/body pair returned by the language model.
 struct CommitDraft: Hashable, Codable, Sendable {
-  #if canImport(FoundationModels)
-    @Guide(
-      description:
-        "The title of a commit. It should be no longer than 50 characters and should summarize the contents of the changeset for other developers reading the commit history. It should describe WHAT was changed."
-    )
-  #endif
+  @Guide(
+    description:
+      "The title of a commit. It should be no longer than 50 characters and should summarize the contents of the changeset for other developers reading the commit history. It should describe WHAT was changed."
+  )
   var subject: String
 
-  #if canImport(FoundationModels)
-    @Guide(
-      description:
-        "A detailed description of the the purposes of the changes. It should describe WHY the changes were made."
-    )
-  #endif
+  @Guide(description: "A detailed description of the the purposes of the changes. It should describe WHY the changes were made.")
   var body: String?
 
   init(subject: String = "", body: String? = nil) {
@@ -83,347 +71,159 @@ struct LLMGenerationResult: Sendable {
   var diagnostics: PromptDiagnostics
 }
 
-#if canImport(FoundationModels)
-  /// Concrete LLM client backed by Apple's FoundationModels framework.
-  struct FoundationModelsClient: LLMClient {
-    /// Controls retry behavior and timeouts for generation requests.
-    struct Configuration {
-      var maxAttempts: Int
-      var requestTimeout: TimeInterval
-      var retryDelay: TimeInterval
-
-      init(maxAttempts: Int = 3, requestTimeout: TimeInterval = 20, retryDelay: TimeInterval = 1) {
-        self.maxAttempts = max(1, maxAttempts)
-        self.requestTimeout = max(0, requestTimeout)
-        self.retryDelay = max(0, retryDelay)
-      }
-    }
-
-    private let generationOptions: GenerationOptions
-    private let configuration: Configuration
-    private let modelProvider: () -> SystemLanguageModel
-
-    init(
-      generationOptions: GenerationOptions = GenerationOptions(
-        sampling: nil,
-        temperature: 0.3,
-        maximumResponseTokens: 512
-      ),
-      configuration: Configuration = Configuration(),
-      modelProvider: @escaping () -> SystemLanguageModel = { SystemLanguageModel.default }
-    ) {
-      self.generationOptions = generationOptions
-      self.configuration = configuration
-      self.modelProvider = modelProvider
-    }
-
-    func generateCommitDraft(from prompt: PromptPackage) async throws -> LLMGenerationResult {
-      let model = modelProvider()
-
-      guard case .available = model.availability else {
-        let reason = availabilityDescription(model.availability)
-        throw CommitGenError.modelUnavailable(reason: reason)
-      }
-
-      let session = LanguageModelSession(
-        model: model,
-        instructions: prompt.systemPrompt
-      )
-
-      var diagnostics = prompt.diagnostics
-      let response = try await session.respond(
-        generating: CommitDraft.self,
-        options: generationOptions
-      ) {
-        prompt.userPrompt
-      }
-
-      let usage = analyzeTranscriptEntries(response.transcriptEntries)
-      let promptTokens = usage.promptTokens
-      let outputTokens = usage.outputTokens
-      let totalTokens: Int?
-      if let promptTokens, let outputTokens {
-        totalTokens = promptTokens + outputTokens
-      } else if let promptTokens {
-        totalTokens = promptTokens
-      } else if let outputTokens {
-        totalTokens = outputTokens
-      } else {
-        totalTokens = nil
-      }
-
-      diagnostics.recordActualTokenUsage(
-        promptTokens: promptTokens,
-        outputTokens: outputTokens,
-        totalTokens: totalTokens
-      )
-
-      return LLMGenerationResult(draft: response.content, diagnostics: diagnostics)
-    }
-
-    private func availabilityDescription(_ availability: SystemLanguageModel.Availability) -> String
-    {
-      switch availability {
-      case .available:
-        ""
-      case .unavailable(let reason):
-        switch reason {
-        case .appleIntelligenceNotEnabled:
-          "Apple Intelligence is turned off in Settings"
-        case .deviceNotEligible:
-          "this device does not support Apple Intelligence"
-        case .modelNotReady:
-          "the model is still preparing; try again later"
-        @unknown default:
-          String(describing: reason)
-        }
-      }
-    }
-
-    private func analyzeTranscriptEntries(
-      _ entries: ArraySlice<FoundationModels.Transcript.Entry>
-    ) -> (promptTokens: Int?, outputTokens: Int?) {
-      var instructionSegments: [String] = []
-      var promptSegments: [String] = []
-      var responseSegments: [String] = []
-
-      for entry in entries {
-        switch entry {
-        case .instructions(let instructions):
-          instructionSegments.append(contentsOf: textSegments(from: instructions.segments))
-        case .prompt(let prompt):
-          promptSegments.append(contentsOf: textSegments(from: prompt.segments))
-        case .response(let response):
-          responseSegments.append(contentsOf: textSegments(from: response.segments))
-        default:
-          continue
-        }
-      }
-
-      let hasPromptSegments = !instructionSegments.isEmpty || !promptSegments.isEmpty
-      let hasResponseSegments = !responseSegments.isEmpty
-
-      let promptTokenCount: Int?
-      if hasPromptSegments {
-        let instructionsCount = estimatedTokenCount(for: instructionSegments)
-        let userCount = estimatedTokenCount(for: promptSegments)
-        promptTokenCount = instructionsCount + userCount
-      } else {
-        promptTokenCount = nil
-      }
-
-      let responseTokenCount: Int?
-      if hasResponseSegments {
-        responseTokenCount = estimatedTokenCount(for: responseSegments)
-      } else {
-        responseTokenCount = nil
-      }
-
-      return (promptTokenCount, responseTokenCount)
-    }
-
-    private func estimatedTokenCount(for segments: [String]) -> Int {
-      guard !segments.isEmpty else { return 0 }
-      let combined = segments.joined(separator: "\n")
-      return PromptDiagnostics.tokenEstimate(forCharacterCount: combined.count)
-    }
-
-    private func textSegments(from segments: [FoundationModels.Transcript.Segment]) -> [String] {
-      segments.compactMap { segment in
-        switch segment {
-        case .text(let text):
-          text.content
-        case .structure(let structured):
-          structured.content.jsonString
-        @unknown default:
-          nil
-        }
-      }
-    }
-  }
-#endif
-
-/// Concrete LLM client backed by Ollama API.
-struct OllamaClient: LLMClient {
+/// Concrete LLM client backed by Apple's FoundationModels framework.
+struct FoundationModelsClient: LLMClient {
+  /// Controls retry behavior and timeouts for generation requests.
   struct Configuration {
-    var model: String
-    var baseURL: String
-    var temperature: Double
-    var maxTokens: Int
-    var logger: CommitGenLogger?
+    var maxAttempts: Int
+    var requestTimeout: TimeInterval
+    var retryDelay: TimeInterval
 
-    init(
-      model: String = "llama3.2",
-      baseURL: String = "http://localhost:11434",
-      temperature: Double = 0.3,
-      maxTokens: Int = 512,
-      logger: CommitGenLogger? = nil
-    ) {
-      self.model = model
-      self.baseURL = baseURL
-      self.temperature = temperature
-      self.maxTokens = maxTokens
-      self.logger = logger
+    init(maxAttempts: Int = 3, requestTimeout: TimeInterval = 20, retryDelay: TimeInterval = 1) {
+      self.maxAttempts = max(1, maxAttempts)
+      self.requestTimeout = max(0, requestTimeout)
+      self.retryDelay = max(0, retryDelay)
     }
   }
 
+  private let generationOptions: GenerationOptions
   private let configuration: Configuration
+  private let modelProvider: () -> SystemLanguageModel
 
-  init(configuration: Configuration = Configuration()) {
+  init(
+    generationOptions: GenerationOptions = GenerationOptions(
+      sampling: nil,
+      temperature: 0.3,
+      maximumResponseTokens: 512
+    ),
+    configuration: Configuration = Configuration(),
+    modelProvider: @escaping () -> SystemLanguageModel = { SystemLanguageModel.default }
+  ) {
+    self.generationOptions = generationOptions
     self.configuration = configuration
+    self.modelProvider = modelProvider
   }
 
   func generateCommitDraft(from prompt: PromptPackage) async throws -> LLMGenerationResult {
-    let url = URL(string: "\(configuration.baseURL)/api/chat")!
-    var request = URLRequest(url: url)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    let model = modelProvider()
 
-    // Structure the messages properly
-    let messages: [[String: String]] = [
-      [
-        "role": "system",
-        "content": prompt.systemPrompt.content,
-      ],
-      [
-        "role": "user",
-        "content": """
-        \(prompt.userPrompt.content)
-
-        IMPORTANT: You must respond with ONLY valid JSON in this exact format, with no additional text before or after:
-        {
-          "subject": "your commit title under 50 characters",
-          "body": "your detailed explanation"
-        }
-
-        Do not include any markdown formatting, code blocks, or explanations. Just the raw JSON object.
-        """,
-      ],
-    ]
-
-    let requestBody: [String: Any] = [
-      "model": configuration.model,
-      "messages": messages,
-      "temperature": configuration.temperature,
-      "stream": false,
-      "format": "json",  // Request JSON format explicitly
-      "options": [
-        "num_predict": configuration.maxTokens
-      ],
-    ]
-
-    // Log the request if verbose logging is enabled
-    configuration.logger?.debug {
-      let systemPreview = prompt.systemPrompt.content.prefix(200)
-      let userPreview = prompt.userPrompt.content.prefix(800)
-      return """
-        📤 Ollama Request to \(configuration.model):
-        ┌─ System Prompt (first 200 chars):
-        │ \(systemPreview)...
-        └─ User Prompt (first 800 chars):
-          \(userPreview)...
-        """
+    guard case .available = model.availability else {
+      let reason = availabilityDescription(model.availability)
+      throw CommitGenError.modelUnavailable(reason: reason)
     }
 
-    request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+    let session = LanguageModelSession(
+      model: model,
+      instructions: prompt.systemPrompt
+    )
 
-    let (data, response) = try await URLSession.shared.data(for: request)
-
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw CommitGenError.llmRequestFailed(reason: "Invalid response type")
-    }
-
-    guard httpResponse.statusCode == 200 else {
-      let errorBody = String(data: data, encoding: .utf8) ?? "no error body"
-      throw CommitGenError.llmRequestFailed(
-        reason: "HTTP \(httpResponse.statusCode): \(errorBody)"
-      )
-    }
-
-    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-
-    guard let message = json?["message"] as? [String: Any],
-      let responseText = message["content"] as? String
-    else {
-      throw CommitGenError.llmRequestFailed(reason: "No message content in Ollama response")
-    }
-
-    // Log the response if verbose logging is enabled
-    configuration.logger?.debug {
-      "📥 Ollama Response: \(responseText.prefix(500))..."
-    }
-
-    // Parse the JSON response from the model
-    let draft = try parseCommitDraft(from: responseText)
-
-    // Create diagnostics
     var diagnostics = prompt.diagnostics
-
-    // Calculate token usage from the response metadata if available
-    let promptTokens: Int?
-    let outputTokens: Int?
-
-    if let promptEvalCount = json?["prompt_eval_count"] as? Int {
-      promptTokens = promptEvalCount
-    } else {
-      promptTokens = PromptDiagnostics.tokenEstimate(
-        forCharacterCount: prompt.systemPrompt.content.count + prompt.userPrompt.content.count
-      )
+    let response = try await session.respond(
+      generating: CommitDraft.self,
+      options: generationOptions
+    ) {
+      prompt.userPrompt
     }
 
-    if let evalCount = json?["eval_count"] as? Int {
-      outputTokens = evalCount
+    let usage = analyzeTranscriptEntries(response.transcriptEntries)
+    let promptTokens = usage.promptTokens
+    let outputTokens = usage.outputTokens
+    let totalTokens: Int?
+    if let promptTokens, let outputTokens {
+      totalTokens = promptTokens + outputTokens
+    } else if let promptTokens {
+      totalTokens = promptTokens
+    } else if let outputTokens {
+      totalTokens = outputTokens
     } else {
-      outputTokens = PromptDiagnostics.tokenEstimate(forCharacterCount: responseText.count)
+      totalTokens = nil
     }
-
-    let totalTokens = (promptTokens ?? 0) + (outputTokens ?? 0)
 
     diagnostics.recordActualTokenUsage(
       promptTokens: promptTokens,
       outputTokens: outputTokens,
-      totalTokens: totalTokens > 0 ? totalTokens : nil
+      totalTokens: totalTokens
     )
 
-    return LLMGenerationResult(draft: draft, diagnostics: diagnostics)
+    return LLMGenerationResult(draft: response.content, diagnostics: diagnostics)
   }
 
-  private func parseCommitDraft(from responseText: String) throws -> CommitDraft {
-    // Clean up the response text
-    var jsonText = responseText.trimmingCharacters(in: .whitespacesAndNewlines)
-
-    // Remove markdown code blocks if present
-    if jsonText.hasPrefix("```json") {
-      jsonText = String(jsonText.dropFirst(7))
-    } else if jsonText.hasPrefix("```") {
-      jsonText = String(jsonText.dropFirst(3))
-    }
-
-    if jsonText.hasSuffix("```") {
-      jsonText = String(jsonText.dropLast(3))
-    }
-
-    jsonText = jsonText.trimmingCharacters(in: .whitespacesAndNewlines)
-
-    guard let jsonData = jsonText.data(using: .utf8) else {
-      throw CommitGenError.llmRequestFailed(reason: "Could not encode response as UTF-8")
-    }
-
-    do {
-      let decoder = JSONDecoder()
-      return try decoder.decode(CommitDraft.self, from: jsonData)
-    } catch {
-      // Fallback: try to parse manually
-      if let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
-        let subject = json["subject"] as? String
-      {
-        let body = json["body"] as? String
-        return CommitDraft(subject: subject, body: body)
+  private func availabilityDescription(_ availability: SystemLanguageModel.Availability) -> String {
+    switch availability {
+    case .available:
+      ""
+    case .unavailable(let reason):
+      switch reason {
+      case .appleIntelligenceNotEnabled:
+        "Apple Intelligence is turned off in Settings"
+      case .deviceNotEligible:
+        "this device does not support Apple Intelligence"
+      case .modelNotReady:
+        "the model is still preparing; try again later"
+      @unknown default:
+        String(describing: reason)
       }
+    }
+  }
 
-      throw CommitGenError.llmRequestFailed(
-        reason: "Could not parse commit draft. Response was: \(jsonText)"
-      )
+  private func analyzeTranscriptEntries(
+    _ entries: ArraySlice<FoundationModels.Transcript.Entry>
+  ) -> (promptTokens: Int?, outputTokens: Int?) {
+    var instructionSegments: [String] = []
+    var promptSegments: [String] = []
+    var responseSegments: [String] = []
+
+    for entry in entries {
+      switch entry {
+      case .instructions(let instructions):
+        instructionSegments.append(contentsOf: textSegments(from: instructions.segments))
+      case .prompt(let prompt):
+        promptSegments.append(contentsOf: textSegments(from: prompt.segments))
+      case .response(let response):
+        responseSegments.append(contentsOf: textSegments(from: response.segments))
+      default:
+        continue
+      }
+    }
+
+    let hasPromptSegments = !instructionSegments.isEmpty || !promptSegments.isEmpty
+    let hasResponseSegments = !responseSegments.isEmpty
+
+    let promptTokenCount: Int?
+    if hasPromptSegments {
+      let instructionsCount = estimatedTokenCount(for: instructionSegments)
+      let userCount = estimatedTokenCount(for: promptSegments)
+      promptTokenCount = instructionsCount + userCount
+    } else {
+      promptTokenCount = nil
+    }
+
+    let responseTokenCount: Int?
+    if hasResponseSegments {
+      responseTokenCount = estimatedTokenCount(for: responseSegments)
+    } else {
+      responseTokenCount = nil
+    }
+
+    return (promptTokenCount, responseTokenCount)
+  }
+
+  private func estimatedTokenCount(for segments: [String]) -> Int {
+    guard !segments.isEmpty else { return 0 }
+    let combined = segments.joined(separator: "\n")
+    return PromptDiagnostics.tokenEstimate(forCharacterCount: combined.count)
+  }
+
+  private func textSegments(from segments: [FoundationModels.Transcript.Segment]) -> [String] {
+    segments.compactMap { segment in
+      switch segment {
+      case .text(let text):
+        text.content
+      case .structure(let structured):
+        structured.content.jsonString
+      @unknown default:
+        nil
+      }
     }
   }
 }

--- a/Sources/SwiftCommitGen/Core/UserConfiguration.swift
+++ b/Sources/SwiftCommitGen/Core/UserConfiguration.swift
@@ -6,7 +6,6 @@ struct UserConfiguration: Codable {
   var defaultVerbose: Bool?
   var defaultQuiet: Bool?
   var defaultGenerationMode: CommitGenOptions.GenerationMode?
-  var llmProvider: CommitGenOptions.LLMProvider?
 }
 
 /// File-backed storage for loading and saving `UserConfiguration` values.


### PR DESCRIPTION
Reverts Iron-Ham/swift-commit-gen#6 

cc: @manelix2000 this creates a number of compile errors when building on macOS 26 – I think realistically the right approach is to create shims of the macros to no-op on previous versions. Perhaps we can separate out the concerns in this PR:

1. Ollama support for macOS 26+
2. Support for previous versions of macOS that don't have foundation models