### PR TITLE
Add progress indicator after detecting staged changes

### DIFF
--- a/Sources/SwiftCommitGen/CommitGenTool.swift
+++ b/Sources/SwiftCommitGen/CommitGenTool.swift
@@ -130,6 +130,7 @@ struct CommitGenTool {
       )
     }
 
+    logger.info("Analyzing staged changes…")
     let stagedStatus = GitStatus(staged: stagedChanges, unstaged: [], untracked: [])
     let summary = try await summarizer.summarize(
       status: stagedStatus,


### PR DESCRIPTION
## Summary

- Adds an "Analyzing staged changes…" progress message after detecting staged changes to provide user feedback during potentially long-running operations
- Fixes a pre-existing failing test that was checking for outdated prompt text

Fixes #19

## Stack

This PR is part of a stack addressing #14 (stalling after detecting staged changes):

1. PR #20 - Fix LLM timeout enforcement (Fixes #16)
2. PR #21 - Fix Git timeout + resource leaks (Fixes #17)
3. PR #22 - Add timeout configuration CLI/config (Fixes #18)
4. **PR #15 (this PR)** - Progress logging (Fixes #19)

## Details

The tool appeared to "stall" after printing `[NOTICE] Detected N staged change(s).` because there was no progress feedback while potentially long-running operations executed:

1. `git diff --cached` (can be slow for large repos or with `--function-context`)
2. Diff parsing and summarization
3. LLM inference

**Before:**
```
[INFO] Repository root: /path/to/repo
[NOTICE] Detected 11 staged change(s).
<long silence>
[NOTICE] Summary: 11 file(s), +234 / -89
```

**After:**
```
[INFO] Repository root: /path/to/repo
[NOTICE] Detected 11 staged change(s).
[INFO] Analyzing staged changes…
[NOTICE] Summary: 11 file(s), +234 / -89
```

## Test plan

- [x] Build passes (`swift build`)
- [x] All 49 tests pass (`swift test`)
- [x] Verified CLI works with `scg generate --help`